### PR TITLE
Health and bomb pickups

### DIFF
--- a/player/player.gd
+++ b/player/player.gd
@@ -115,3 +115,10 @@ func hurt(damage: float) -> void:
 
 	if health <= 0:
 		pass # player death is not yet implemented
+
+## Does the opposite.
+func heal(gained: float) -> void:
+	if health>=max_health: return
+	
+	health+=gained
+	print("player.gd: Health raised to %s/%s" % [health, max_health])

--- a/player/sword/thrown_sword.gd
+++ b/player/sword/thrown_sword.gd
@@ -19,6 +19,9 @@ var direction: Vector2               ## Direction vector of the sword
 var player_dist: Vector2             ## Distance vector from the sword to the player
 var local_acceleration: float        ## Local acceleration applied to the sword (adjustable)
 
+var held_items: Array[Node2D]
+
+
 ## Signal emitted when the sword bounces, providing bounce intensity
 signal sword_bounced(intensity: float)
 
@@ -50,6 +53,8 @@ func _physics_process(delta: float) -> void:
 	# Determine if the sword is close enough to the player using the dot product
 	var cos_theta: float = player_dist.dot(old_player_dist) / (player_dist.length() * old_player_dist.length())
 	if player_dist.length() <= 100 and cos_theta < 0 and returning:
+		for item: Node in held_items:
+			item.reparent(get_parent())
 		queue_free()
 
 	# Handle movement and acceleration while returning or still thrown
@@ -91,10 +96,12 @@ func _on_collision(collision: KinematicCollision2D) -> void:
 ## Grab items when they enter the grab area
 func _on_grab_area_body_entered(body: Node2D) -> void:
 	if not body.is_in_group("Item"): return
+	if body in held_items: return
 	
 	var reparent_fn := func() -> void:
 		body.position = Vector2.ZERO
 		body.reparent(self)
+		held_items.append(body)
 	
 	# it's bad to change the tree in response to a physics signal, so defer this call
 	reparent_fn.call_deferred()

--- a/test_scenes/boomerang_test.tscn
+++ b/test_scenes/boomerang_test.tscn
@@ -2,8 +2,8 @@
 
 [ext_resource type="PackedScene" uid="uid://c7ck7ril2jix2" path="res://player/player.tscn" id="1_vbyjc"]
 [ext_resource type="PackedScene" uid="uid://ch344rluh4xbs" path="res://world/camera/main_cam.tscn" id="2_nb3vp"]
-[ext_resource type="PackedScene" uid="uid://bdniv62roo8ov" path="res://world/environment/pickups/item_temp_1.tscn" id="4_67m01"]
 [ext_resource type="Texture2D" uid="uid://dymucenpxmluo" path="res://icon.svg" id="4_owqiy"]
+[ext_resource type="PackedScene" uid="uid://bw27nxu2m3rbe" path="res://world/environment/pickups/pickup_health.tscn" id="5_ejux5"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_krk6c"]
 size = Vector2(129.5, 126)
@@ -93,5 +93,20 @@ shape = SubResource("RectangleShape2D_krk6c")
 [node name="Sprite2D" type="Sprite2D" parent="Walls/Node2D6"]
 texture = ExtResource("4_owqiy")
 
-[node name="ItemTemp1" parent="." instance=ExtResource("4_67m01")]
-position = Vector2(1006, 174)
+[node name="pickup_health" parent="." instance=ExtResource("5_ejux5")]
+position = Vector2(660, 506)
+
+[node name="pickup_health2" parent="." instance=ExtResource("5_ejux5")]
+position = Vector2(255, 192)
+
+[node name="pickup_health3" parent="." instance=ExtResource("5_ejux5")]
+position = Vector2(491, 439)
+
+[node name="pickup_health4" parent="." instance=ExtResource("5_ejux5")]
+position = Vector2(498, 458)
+
+[node name="pickup_health5" parent="." instance=ExtResource("5_ejux5")]
+position = Vector2(481, 492)
+
+[node name="pickup_health6" parent="." instance=ExtResource("5_ejux5")]
+position = Vector2(490, 525)

--- a/world/environment/pickups/generic_item_pickup.gd
+++ b/world/environment/pickups/generic_item_pickup.gd
@@ -1,0 +1,30 @@
+extends CharacterBody2D
+
+## GENERIC ITEM PICKUP
+
+## This is for when the player picks up standard stuff like bombs and health. Things that make numbers go up, instead of quest items or keys.
+
+## This enum holds the possible item types. Add more as needed.
+## This is being restated every time an item spawns. Maybe should be in an autoload elsewhere?
+enum item_type{
+	HEALTH,
+	BOMB
+}
+
+## Now we tell this particular instance what its identity is, what part of the enum it is.
+@export var identity:=item_type.HEALTH
+@export var amount : int = 15
+#func _ready() -> void:
+#	assert(inventory_key != "", "Item '%s' has an empty inventory key!" % inventory_key)
+
+
+func _on_pickup_area_body_entered(body: Node2D) -> void:
+	if body is not Player: return
+
+	match identity:
+		item_type.HEALTH:
+			if body.health>=body.max_health:return
+			body.heal(amount)
+		item_type.BOMB:
+			PlayerInventory.bombs+=amount
+	queue_free()

--- a/world/environment/pickups/inventory_item_pickup.gd
+++ b/world/environment/pickups/inventory_item_pickup.gd
@@ -9,7 +9,7 @@ func _ready() -> void:
 
 func _on_pickup_area_body_entered(body: Node2D) -> void:
 	if body is not Player: return
-	
+
 	PlayerInventory.add_quantity(inventory_key, 1)
 	queue_free()
 	print("inventory_item_pickup.gd: Picked up item '%s'" % inventory_key)

--- a/world/environment/pickups/pickup_bomb.tscn
+++ b/world/environment/pickups/pickup_bomb.tscn
@@ -1,0 +1,35 @@
+[gd_scene load_steps=5 format=3 uid="uid://cxgodqe6st3jf"]
+
+[ext_resource type="Script" path="res://world/environment/pickups/generic_item_pickup.gd" id="1_3pdfe"]
+[ext_resource type="Texture2D" uid="uid://dymucenpxmluo" path="res://icon.svg" id="2_44yxa"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_my72a"]
+radius = 22.0
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_n4s5b"]
+radius = 111.803
+
+[node name="pickup_bomb" type="CharacterBody2D" groups=["Item"]]
+collision_layer = 16
+collision_mask = 0
+script = ExtResource("1_3pdfe")
+identity = 1
+amount = 1
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("CircleShape2D_my72a")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+scale = Vector2(0.3, 0.3)
+texture = ExtResource("2_44yxa")
+
+[node name="PickupArea" type="Area2D" parent="."]
+collision_layer = 0
+collision_mask = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="PickupArea"]
+scale = Vector2(0.3, 0.3)
+shape = SubResource("CircleShape2D_n4s5b")
+debug_color = Color(0, 0.6, 0.701961, 0.0784314)
+
+[connection signal="body_entered" from="PickupArea" to="." method="_on_pickup_area_body_entered"]

--- a/world/environment/pickups/pickup_health.tscn
+++ b/world/environment/pickups/pickup_health.tscn
@@ -1,0 +1,33 @@
+[gd_scene load_steps=5 format=3 uid="uid://bw27nxu2m3rbe"]
+
+[ext_resource type="Script" path="res://world/environment/pickups/generic_item_pickup.gd" id="1_28850"]
+[ext_resource type="Texture2D" uid="uid://jj82j3q3he5c" path="res://demo_art/tre_test_item.png" id="2_3im74"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_my72a"]
+radius = 22.0
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_n4s5b"]
+radius = 111.803
+
+[node name="pickup_health" type="CharacterBody2D" groups=["Item"]]
+collision_layer = 16
+collision_mask = 0
+script = ExtResource("1_28850")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("CircleShape2D_my72a")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+scale = Vector2(0.134095, 0.134095)
+texture = ExtResource("2_3im74")
+
+[node name="PickupArea" type="Area2D" parent="."]
+collision_layer = 0
+collision_mask = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="PickupArea"]
+scale = Vector2(0.3, 0.3)
+shape = SubResource("CircleShape2D_n4s5b")
+debug_color = Color(0, 0.6, 0.701961, 0.0784314)
+
+[connection signal="body_entered" from="PickupArea" to="." method="_on_pickup_area_body_entered"]


### PR DESCRIPTION
fixes #17, #16 

This was actually the same problem so now there's both of them. pickup_bomb and pickup_health are two scenes that are almost identical, but they're separate so level designers have easier lives. The only difference is the setting of some export variables and sprites, but this way a designer can just drag and drop things into a level without personally tweaking the item settings.


Other edits outside of pickups directly: Player has an added heal function, and Thrown Sword has some checks to make sure it drops objects before queue_free-ing. The latter makes sure a player doesn't despawn health from existence if they boomerang a pickup when they don't need it.