### PR TITLE
Save chest between scenes

### DIFF
--- a/autoloads/chest_between_scenes/chest_between_scenes.gd
+++ b/autoloads/chest_between_scenes/chest_between_scenes.gd
@@ -1,0 +1,21 @@
+extends Node
+
+@export var opened_chest : Array[NodePath]
+@onready var num_open_chest : int
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass
+	
+func add_to_opened_chest(new_chest: NodePath) -> void:
+	opened_chest.append(new_chest)
+	print("Chest been added " + str(new_chest))
+	
+func check_if_opened(chest_to_check: NodePath) -> bool:
+	
+	return false

--- a/autoloads/chest_between_scenes/chest_between_scenes.gd
+++ b/autoloads/chest_between_scenes/chest_between_scenes.gd
@@ -1,7 +1,7 @@
 extends Node
 
 @export var opened_chest : Array[NodePath]
-@onready var num_open_chest : int
+## Will track if chest has already been opened
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -12,10 +12,16 @@ func _ready() -> void:
 func _process(delta: float) -> void:
 	pass
 	
+#Called by chest, adds chest's path to list
 func add_to_opened_chest(new_chest: NodePath) -> void:
 	opened_chest.append(new_chest)
 	print("Chest been added " + str(new_chest))
 	
+#When chest is loaded it will call this function to see if it was opened before
 func check_if_opened(chest_to_check: NodePath) -> bool:
-	
-	return false
+	for saved_chest in opened_chest:      #loop through list of opened chest
+		if chest_to_check == saved_chest:
+			print("We have opened this test before")
+			return true  # it has been opened
+	print("We have not opened " + str(chest_to_check))
+	return false   #it hasn't been opened

--- a/autoloads/chest_between_scenes/chest_between_scenes.tscn
+++ b/autoloads/chest_between_scenes/chest_between_scenes.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://4xsfryosg0g8"]
+
+[ext_resource type="Script" path="res://autoloads/chest_between_scenes/chest_between_scenes.gd" id="1_oyp8j"]
+
+[node name="ChestBetweenScenes" type="Node"]
+script = ExtResource("1_oyp8j")

--- a/project.godot
+++ b/project.godot
@@ -22,6 +22,7 @@ DialogueManager="*res://dialogic_example/dialogue_manager.gd"
 Dialogic="*res://addons/dialogic/Core/DialogicGameHandler.gd"
 PlayerInventory="*res://autoloads/player_inventory/player_inventory.tscn"
 SceneTransition="*res://autoloads/scene_transition/scene_transition.tscn"
+ChestBetweenScenes="*res://autoloads/chest_between_scenes/chest_between_scenes.tscn"
 
 [debug]
 

--- a/test_scenes/chest_between_scenes_test_1.tscn
+++ b/test_scenes/chest_between_scenes_test_1.tscn
@@ -1,0 +1,42 @@
+[gd_scene load_steps=7 format=3 uid="uid://dvwifj1dtyxw0"]
+
+[ext_resource type="PackedScene" uid="uid://c7ck7ril2jix2" path="res://player/player.tscn" id="1_ax6hk"]
+[ext_resource type="PackedScene" uid="uid://bom8mopkckp5y" path="res://world/environment/chest/chest.tscn" id="2_cwji3"]
+[ext_resource type="Texture2D" uid="uid://dc4pcxr2lfkka" path="res://demo_art/dungeon_entrance.png" id="3_6i27p"]
+[ext_resource type="PackedScene" uid="uid://b2bxxuuc3qgex" path="res://test_scenes/test_chest_items/tre_test_item.tscn" id="3_lmax1"]
+[ext_resource type="Script" path="res://world/transition_trigger/transition_trigger.gd" id="4_cgwf2"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_7gni5"]
+size = Vector2(158, 146)
+
+[node name="ChestBetweenScenesTest1" type="Node2D"]
+
+[node name="Player" parent="." instance=ExtResource("1_ax6hk")]
+position = Vector2(981, 324)
+
+[node name="Chest" parent="." instance=ExtResource("2_cwji3")]
+position = Vector2(543, 242)
+loot_table = Array[PackedScene]([ExtResource("3_lmax1")])
+
+[node name="Chest2" parent="." instance=ExtResource("2_cwji3")]
+position = Vector2(821, 124)
+loot_table = Array[PackedScene]([ExtResource("3_lmax1")])
+
+[node name="DungeonEntrance" type="Sprite2D" parent="."]
+position = Vector2(208, 92)
+scale = Vector2(2.33037, 2.33037)
+texture = ExtResource("3_6i27p")
+
+[node name="TransitionScene" type="Area2D" parent="DungeonEntrance"]
+position = Vector2(-6.00761, 27.8925)
+scale = Vector2(0.429116, 0.429116)
+collision_layer = 0
+collision_mask = 2
+script = ExtResource("4_cgwf2")
+scene = "uid://cm5fbuxkg0pl7"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="DungeonEntrance/TransitionScene"]
+position = Vector2(6, -13)
+shape = SubResource("RectangleShape2D_7gni5")
+
+[connection signal="body_entered" from="DungeonEntrance/TransitionScene" to="DungeonEntrance/TransitionScene" method="_on_body_entered"]

--- a/test_scenes/chest_between_scenes_test_2.tscn
+++ b/test_scenes/chest_between_scenes_test_2.tscn
@@ -9,7 +9,7 @@
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_7gni5"]
 size = Vector2(158, 146)
 
-[node name="ChestBetweenScenesTest1" type="Node2D"]
+[node name="ChestBetweenScenesTest2" type="Node2D"]
 
 [node name="Player" parent="." instance=ExtResource("1_jkccg")]
 position = Vector2(167, 375)

--- a/test_scenes/chest_between_scenes_test_2.tscn
+++ b/test_scenes/chest_between_scenes_test_2.tscn
@@ -1,0 +1,38 @@
+[gd_scene load_steps=7 format=3 uid="uid://cm5fbuxkg0pl7"]
+
+[ext_resource type="PackedScene" uid="uid://c7ck7ril2jix2" path="res://player/player.tscn" id="1_jkccg"]
+[ext_resource type="PackedScene" uid="uid://bom8mopkckp5y" path="res://world/environment/chest/chest.tscn" id="2_cxaep"]
+[ext_resource type="Texture2D" uid="uid://dc4pcxr2lfkka" path="res://demo_art/dungeon_entrance.png" id="3_6gajq"]
+[ext_resource type="PackedScene" uid="uid://b2bxxuuc3qgex" path="res://test_scenes/test_chest_items/tre_test_item.tscn" id="3_pyaji"]
+[ext_resource type="Script" path="res://world/transition_trigger/transition_trigger.gd" id="4_6inb3"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_7gni5"]
+size = Vector2(158, 146)
+
+[node name="ChestBetweenScenesTest1" type="Node2D"]
+
+[node name="Player" parent="." instance=ExtResource("1_jkccg")]
+position = Vector2(167, 375)
+
+[node name="Chest" parent="." instance=ExtResource("2_cxaep")]
+position = Vector2(562, 257)
+loot_table = Array[PackedScene]([ExtResource("3_pyaji")])
+
+[node name="DungeonEntrance" type="Sprite2D" parent="."]
+position = Vector2(988, 90)
+scale = Vector2(2.33037, 2.33037)
+texture = ExtResource("3_6gajq")
+
+[node name="TransitionScene" type="Area2D" parent="DungeonEntrance"]
+position = Vector2(-6.00761, 27.8925)
+scale = Vector2(0.429116, 0.429116)
+collision_layer = 0
+collision_mask = 2
+script = ExtResource("4_6inb3")
+scene = "uid://dvwifj1dtyxw0"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="DungeonEntrance/TransitionScene"]
+position = Vector2(6, -13)
+shape = SubResource("RectangleShape2D_7gni5")
+
+[connection signal="body_entered" from="DungeonEntrance/TransitionScene" to="DungeonEntrance/TransitionScene" method="_on_body_entered"]

--- a/world/environment/chest/chest.gd
+++ b/world/environment/chest/chest.gd
@@ -32,6 +32,8 @@ func open_chest() -> void:
 	closed_sprite.visible = false
 	open_sprite.visible = true
 	
+	ChestBetweenScenes.add_to_opened_chest(self.get_path())
+	
 	# Picks a random item from the list and spawns it at the chest.
 	var item : PackedScene = loot_table.pick_random()
 	var spawned := item.instantiate()

--- a/world/environment/chest/chest.gd
+++ b/world/environment/chest/chest.gd
@@ -11,6 +11,9 @@ var player: Player
 @onready var open_sprite: Sprite2D = %OpenSprite
 
 func _ready() -> void:
+	opened = ChestBetweenScenes.check_if_opened(self.get_path()) #See if it has been opened before
+	if (opened):
+		pre_opened_chest() # if it was opened go here
 	player = Player.instance
 	assert(player != null, "Player does not exist in the scene!")
 
@@ -40,3 +43,7 @@ func open_chest() -> void:
 	spawned.position = position
 	add_sibling(spawned)
 	
+func pre_opened_chest() -> void: #will dispaly chest as being open is already opened.
+	print("This chest has already been opened")
+	closed_sprite.visible = false
+	open_sprite.visible = true

--- a/world/latest_demo.tscn
+++ b/world/latest_demo.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="PackedScene" uid="uid://c7ck7ril2jix2" path="res://player/player.tscn" id="2_vi53h"]
 [ext_resource type="PackedScene" uid="uid://bom8mopkckp5y" path="res://world/environment/chest/chest.tscn" id="3_iuoyy"]
 [ext_resource type="PackedScene" uid="uid://bdniv62roo8ov" path="res://world/environment/pickups/item_temp_1.tscn" id="4_05emf"]
-[ext_resource type="PackedScene" path="res://world/environment/pickups/pickup_bomb.tscn" id="4_xhn3s"]
+[ext_resource type="PackedScene" uid="uid://cxgodqe6st3jf" path="res://world/environment/pickups/pickup_bomb.tscn" id="4_xhn3s"]
 [ext_resource type="PackedScene" uid="uid://ch344rluh4xbs" path="res://world/camera/main_cam.tscn" id="7_7fnsb"]
 [ext_resource type="PackedScene" uid="uid://d3xngexqsy6m7" path="res://enemy_spawner/enemy_spawner.tscn" id="7_007xo"]
 [ext_resource type="Texture2D" uid="uid://dymucenpxmluo" path="res://icon.svg" id="8_umcft"]


### PR DESCRIPTION
fixes #53 

Created new Autoload chest_between_scenes

When a chest is opened it will have its node path added to array opened_chest in chest_between_scenes.
On ready, chest will ask chest_between_scenes if it has been opened (check_if_opened)
chest_between_scene will see if it's node path is saved in opened_chest, returns true/false
If true chest will show as being open and will not spawn an item when interacted.