### PR TITLE
Added hitbox

### DIFF
--- a/enemy/base_enemy.tscn
+++ b/enemy/base_enemy.tscn
@@ -1,7 +1,20 @@
-[gd_scene load_steps=2 format=3 uid="uid://blpi4x6if673v"]
+[gd_scene load_steps=3 format=3 uid="uid://blpi4x6if673v"]
 
 [ext_resource type="Script" path="res://enemy/enemy.gd" id="1_xa7a1"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_fdgx0"]
+size = Vector2(117, 108)
 
 [node name="BaseEnemy" type="CharacterBody2D" groups=["Enemy"]]
 collision_layer = 4
 script = ExtResource("1_xa7a1")
+
+[node name="hitbox" type="Area2D" parent="."]
+collision_layer = 0
+collision_mask = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="hitbox"]
+shape = SubResource("RectangleShape2D_fdgx0")
+
+[connection signal="body_entered" from="hitbox" to="." method="_on_area_2d_body_entered"]
+[connection signal="body_entered" from="hitbox" to="." method="_on_hitbox_body_entered"]

--- a/enemy/enemy.gd
+++ b/enemy/enemy.gd
@@ -5,6 +5,8 @@
 class_name Enemy extends CharacterBody2D
 
 @export var max_health: int = 3
+@export var damage : int = 1
+@export var knockback_force : int = 10
 @onready var health := max_health
 
 ## Damages the enemy, killing it if its health drops below zero.
@@ -19,3 +21,13 @@ func hurt(damage_event: DamageEvent) -> void:
 
 	if health <= 0:
 		queue_free()
+
+func _on_hitbox_body_entered(body: Node2D) -> void:
+	var knockbackVector : Vector2 = Vector2.ZERO
+	var player := body as Player
+	if player != null:
+		player.health -= damage
+		print("player has taken damage, health: %s/%s" % [player.health,player.max_health])
+		knockbackVector = (player.global_position - global_position) * knockback_force
+		player.add_force(knockbackVector)
+		

--- a/enemy/test_enemy/test_enemy.gd
+++ b/enemy/test_enemy/test_enemy.gd
@@ -21,8 +21,3 @@ func _physics_process(_delta: float) -> void:
 	move_and_slide()
 
 	look_at(_player.global_position)
-
-func _on_hitting_area_body_entered(body: Node2D) -> void:
-	var player := body as Player
-	if player != null:
-		player.hurt(1)

--- a/enemy/test_enemy/test_enemy.tscn
+++ b/enemy/test_enemy/test_enemy.tscn
@@ -1,33 +1,22 @@
-[gd_scene load_steps=6 format=3 uid="uid://uj2rytnj1h4"]
+[gd_scene load_steps=5 format=3 uid="uid://uj2rytnj1h4"]
 
 [ext_resource type="PackedScene" uid="uid://blpi4x6if673v" path="res://enemy/base_enemy.tscn" id="1_oqpld"]
 [ext_resource type="Script" path="res://enemy/test_enemy/test_enemy.gd" id="2_yeqgq"]
 [ext_resource type="Texture2D" uid="uid://deern6512fesn" path="res://demo_art/test_enemy.svg" id="3_72tns"]
-
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_0i45s"]
-size = Vector2(97, 98)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_6fsdk"]
 size = Vector2(117, 107)
 
 [node name="TestEnemy" instance=ExtResource("1_oqpld")]
 script = ExtResource("2_yeqgq")
-max_health = null
 
 [node name="TestEnemy" type="Sprite2D" parent="." index="0"]
 scale = Vector2(0.75, 0.75)
 texture = ExtResource("3_72tns")
 
-[node name="HittingArea" type="Area2D" parent="." index="1"]
-collision_layer = 0
-collision_mask = 2
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="HittingArea" index="0"]
-position = Vector2(-0.5, 0)
-shape = SubResource("RectangleShape2D_0i45s")
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="." index="2"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="." index="1"]
 position = Vector2(2.5, 2.5)
 shape = SubResource("RectangleShape2D_6fsdk")
 
-[connection signal="body_entered" from="HittingArea" to="." method="_on_hitting_area_body_entered"]
+[node name="CollisionShape2D" parent="hitbox" index="0"]
+position = Vector2(1, 0)

--- a/player/player.gd
+++ b/player/player.gd
@@ -8,8 +8,10 @@ static var instance: Player
 
 @export var max_stamina: float = 3.0
 @onready var stamina: float = max_stamina
+@onready var force_applied: Vector2 = Vector2.ZERO ## All external forces applied
 @export var stamina_recovery_rate: float = 1.0
 
+@export var knockback_friction: float = 5.0 ## How fast the player slows down from knockback
 var active_sword: ThrownSword ## The active thrown sword. Null if the player is currently holding the sword
 
 ## On controller, if the aim stick isn't held in any direction, the last non-zero aim will be used
@@ -108,6 +110,8 @@ func _physics_process(_delta: float) -> void:
 	if (Input.is_action_just_pressed("dog_roll")):
 		start_roll()
 	
+	velocity += force_applied 	
+	force_applied = force_applied.lerp(Vector2.ZERO, _delta * knockback_friction)
 	move_and_slide()
 
 ## Damages the player, lowering its health.
@@ -130,3 +134,7 @@ func heal(gained: float) -> void:
 	
 	health+=gained
 	print("player.gd: Health raised to %s/%s" % [health, max_health])
+
+func add_force(force: Vector2) -> void: ## add any force onto the player
+	force_applied += force
+	

--- a/world/latest_demo.tscn
+++ b/world/latest_demo.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="PackedScene" uid="uid://c7ck7ril2jix2" path="res://player/player.tscn" id="2_vi53h"]
 [ext_resource type="PackedScene" uid="uid://bom8mopkckp5y" path="res://world/environment/chest/chest.tscn" id="3_iuoyy"]
 [ext_resource type="PackedScene" uid="uid://bdniv62roo8ov" path="res://world/environment/pickups/item_temp_1.tscn" id="4_05emf"]
-[ext_resource type="PackedScene" path="res://world/environment/pickups/pickup_bomb.tscn" id="4_xhn3s"]
+[ext_resource type="PackedScene" uid="uid://cxgodqe6st3jf" path="res://world/environment/pickups/pickup_bomb.tscn" id="4_xhn3s"]
 [ext_resource type="PackedScene" uid="uid://ch344rluh4xbs" path="res://world/camera/main_cam.tscn" id="7_7fnsb"]
 [ext_resource type="PackedScene" uid="uid://d3xngexqsy6m7" path="res://enemy_spawner/enemy_spawner.tscn" id="7_007xo"]
 [ext_resource type="Texture2D" uid="uid://dymucenpxmluo" path="res://icon.svg" id="8_umcft"]
@@ -26,7 +26,6 @@ size = Vector2(158, 146)
 
 [node name="TestEnemy" parent="." instance=ExtResource("1_h18tn")]
 position = Vector2(351, 619)
-max_health = 3
 
 [node name="Player" parent="." instance=ExtResource("2_vi53h")]
 position = Vector2(534, 261)


### PR DESCRIPTION
The hitbox is an area2d which is on the base enemy.
Every enemy has an exported damage and knockback value.
The player now has an add_force method, which allows outside forces to be added to the player
-these are processed before moveandslide(), and are reduced via the lerp function

closes #75 
 