### PR TITLE
Fixed the bomb-sword issue

### DIFF
--- a/player/bomb.gd
+++ b/player/bomb.gd
@@ -36,14 +36,14 @@ func explode() -> void:
 #This change was made in response to the bomb immediately exploding if it was hit by the sword, which caused the player
 #to have a chance if damaging themselves as soon as they threw the bomb.
 func hurt(_damage_event: DamageEvent) -> void:
-	if(velocity == Vector2(0,0)):
+	const STILL_SPEED := 50.0 # bomb is considered stationary of below this speed
+	if velocity.length() < STILL_SPEED:
 		explode()
 
 #Updates the velocity of the bomb, and ensures that after the bomb has reached a small enough velocity it stops
 func _physics_process(_delta: float) -> void:
 	velocity *= 0.9
 	
-	if(abs(velocity.x) < 10 and abs(velocity.y) < 10):
-		velocity = Vector2(0,0)
+	print("speed = ", velocity.length())
 		
 	move_and_slide()

--- a/player/bomb.gd
+++ b/player/bomb.gd
@@ -32,10 +32,18 @@ func explode() -> void:
 
 	queue_free()
 
+#Only will be called when the bomb is hit by the players' sword, and will only explode if the bomb is stopped.
+#This change was made in response to the bomb immediately exploding if it was hit by the sword, which caused the player
+#to have a chance if damaging themselves as soon as they threw the bomb.
 func hurt(_damage_event: DamageEvent) -> void:
-	explode()
-	return
+	if(velocity == Vector2(0,0)):
+		explode()
 
+#Updates the velocity of the bomb, and ensures that after the bomb has reached a small enough velocity it stops
 func _physics_process(_delta: float) -> void:
 	velocity *= 0.9
+	
+	if(abs(velocity.x) < 10 and abs(velocity.y) < 10):
+		velocity = Vector2(0,0)
+		
 	move_and_slide()

--- a/world/latest_demo_2.tscn
+++ b/world/latest_demo_2.tscn
@@ -1839,6 +1839,6 @@ position = Vector2(617, 702)
 position = Vector2(-2330, 2364)
 
 [node name="Player" parent="." index="16"]
-position = Vector2(534, 628)
+position = Vector2(-2535, 1515)
 
 [connection signal="body_entered" from="PuzzleArea/DungeonEntrance/TransitionScene" to="PuzzleArea/DungeonEntrance/TransitionScene" method="_on_body_entered"]


### PR DESCRIPTION
Fixed the issue of the bomb exploding as soon as the sword hit it, regardless of the speed of the bomb. This allowed the bomb to potentially explode as soon as the player threw it, if either the player also threw their sword at the same time, or the sword was coming back to the player. 

The fix involves setting the velocity of the bomb as just zero if its velocity is small enough, which does change the distance the bomb travels (by roughly 3-5% or so, to change it just modify the two numbers in the less than inequality checks in the _physics_process() function) but also ensures the bomb will eventually stop as we simply multiply its speed by 90% every frame, allowing the sword to explode it once it stops.