### PR TITLE
allow breakable objects to specify damage type

### DIFF
--- a/generic/damage_event.gd
+++ b/generic/damage_event.gd
@@ -1,11 +1,16 @@
 class_name DamageEvent
 
+enum DamageType {
+	Undefined = 1 << 0,
+	Bomb = 1 << 1,
+}
 var damage: int ## The amount of damage (in half hearts) the damage event should deal
 var knockback: Vector2 ## Velocity added to thing being hit. This will only do anything if the enemy specifically handles it
-
-func _init(attack_damage: int, attack_knockback := Vector2.ZERO) -> void:
+var damage_type: int
+func _init(attack_damage: int, attack_knockback := Vector2.ZERO, attack_type := DamageType.Undefined) -> void:
 	self.damage = attack_damage
 	self.knockback = attack_knockback
+	self.damage_type = attack_type
 	
 	
 	

--- a/player/bomb.gd
+++ b/player/bomb.gd
@@ -19,10 +19,8 @@ func explode() -> void:
 	print(damaged_things)
 	for thing in damaged_things:
 		if thing.has_method("hurt") and !(thing is Bomb):
-			if (thing is Player):
-				thing.hurt(DamageEvent.new(damage_to_player, velocity.normalized() * knockback)) 
-			else:
-				thing.hurt(DamageEvent.new(damage, velocity.normalized() * knockback)) 
+			var hurt_damage := damage_to_player if thing is Player else damage
+			thing.hurt(DamageEvent.new(hurt_damage, velocity.normalized() * knockback, DamageEvent.DamageType.Bomb)) 
 	
 	#TODO: change animation
 	get_node("BombSprite").scale.x *= 4

--- a/test_scenes/bomb_walls_things_test.tscn
+++ b/test_scenes/bomb_walls_things_test.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=5 format=3 uid="uid://db7gdrkdq52ss"]
+
+[ext_resource type="PackedScene" uid="uid://5x8wo3lcwigq" path="res://world/objects/breakable_object/breakable_object.tscn" id="1_q2wxb"]
+[ext_resource type="PackedScene" uid="uid://c7ck7ril2jix2" path="res://player/player.tscn" id="2_uqnjb"]
+[ext_resource type="PackedScene" uid="uid://bwo5q4wroaigc" path="res://world/interactable/transition_trigger/transition_trigger.tscn" id="3_15pve"]
+[ext_resource type="Texture2D" uid="uid://dc4pcxr2lfkka" path="res://demo_art/dungeon_entrance.png" id="4_athc7"]
+
+[node name="Node2D" type="Node2D"]
+
+[node name="BreakableObject" parent="." instance=ExtResource("1_q2wxb")]
+position = Vector2(162, 115)
+
+[node name="Player" parent="." instance=ExtResource("2_uqnjb")]
+position = Vector2(782, 341)
+
+[node name="TransitionScene" parent="." instance=ExtResource("3_15pve")]
+position = Vector2(1002, 147)
+scene_name = "break_things_reset_test"
+
+[node name="DungeonEntrance" type="Sprite2D" parent="."]
+position = Vector2(1007, 128)
+texture = ExtResource("4_athc7")

--- a/test_scenes/break_things_test.tscn
+++ b/test_scenes/break_things_test.tscn
@@ -1,22 +1,13 @@
-[gd_scene load_steps=5 format=3 uid="uid://dnjplqbg5h6c8"]
+[gd_scene load_steps=3 format=3 uid="uid://dnjplqbg5h6c8"]
 
 [ext_resource type="PackedScene" uid="uid://5x8wo3lcwigq" path="res://world/objects/breakable_object/breakable_object.tscn" id="1_xlgn6"]
 [ext_resource type="PackedScene" uid="uid://c7ck7ril2jix2" path="res://player/player.tscn" id="2_oyh4h"]
-[ext_resource type="PackedScene" uid="uid://bwo5q4wroaigc" path="res://world/interactable/transition_trigger/transition_trigger.tscn" id="3_dhw5a"]
-[ext_resource type="Texture2D" uid="uid://dc4pcxr2lfkka" path="res://demo_art/dungeon_entrance.png" id="4_gu7w7"]
 
 [node name="Node2D" type="Node2D"]
 
 [node name="BreakableObject" parent="." instance=ExtResource("1_xlgn6")]
 position = Vector2(162, 115)
+breakable_by = 2
 
 [node name="Player" parent="." instance=ExtResource("2_oyh4h")]
 position = Vector2(782, 341)
-
-[node name="TransitionScene" parent="." instance=ExtResource("3_dhw5a")]
-position = Vector2(1002, 147)
-scene_name = "break_things_reset_test"
-
-[node name="DungeonEntrance" type="Sprite2D" parent="."]
-position = Vector2(1007, 128)
-texture = ExtResource("4_gu7w7")

--- a/world/objects/breakable_object/breakable_object.gd
+++ b/world/objects/breakable_object/breakable_object.gd
@@ -4,11 +4,22 @@ class_name BreakableObject extends StaticBody2D
 @onready var broken := get_node("BrokenWall")
 @onready var hitbox := get_node("Hitbox")
 @export_range(0, 1) var pickup_drop_chance: float = 0.5 ## Chance of dropping a pick-up 
-
+@export_flags("Undefined", "Bomb") var breakable_by: int = DamageEvent.DamageType.Undefined
 func hurt(_damage_event: DamageEvent) -> void:
+	#If no shared damage type, skip
+	if _damage_event.damage_type & breakable_by == 0:
+		return
 	#Totally not stolen from enemine
 	if (randf() <= pickup_drop_chance):
-
+		drop_item()
+	
+	#Change collision & Sprite to broken
+	not_broken.hide()
+	broken.show()
+	set_collision_layer_value(1,false)
+	set_collision_layer_value(3,false)
+	
+func drop_item() -> void:
 		# add bombs, health, and stamina to the list of possible drops, after checking if they're eligible
 		var eligible_pickup_paths: Array[String]
 		if (Player.instance.health < Player.instance.max_health):
@@ -19,7 +30,7 @@ func hurt(_damage_event: DamageEvent) -> void:
 		
 		# If, somehow, there are no eligible items, then sound the alarms and bail 
 		if (eligible_pickup_paths.is_empty()):
-			push_error("enemy.gd: No valid pickup drops were possible!")
+			push_error("breakable_object.gd: No valid pickup drops were possible!")
 			return
 		
 		# pick an eligible item and get the scene path
@@ -28,14 +39,6 @@ func hurt(_damage_event: DamageEvent) -> void:
 		dropped_item.position = position
 		add_sibling.call_deferred(dropped_item)
 		print("Item '", dropped_item.name, "' was dropped by ", get_path())
-	
-	#Change collision & Sprite to broken
-	not_broken.hide()
-	broken.show()
-	set_collision_layer_value(1,false)
-	set_collision_layer_value(3,false)
-	
-	
 
 func _ready() -> void:
 	#Change collision & Sprite to unbroken


### PR DESCRIPTION
Breakable walls now have a flag for what type of damage can break it. The only one distinguished right now are bombs. Resolves #194 