### PR TITLE
Added multi activators

### DIFF
--- a/test_scenes/multi_switch_test.tscn
+++ b/test_scenes/multi_switch_test.tscn
@@ -1,0 +1,37 @@
+[gd_scene load_steps=6 format=3 uid="uid://d3gw8agbyr31b"]
+
+[ext_resource type="PackedScene" uid="uid://b60qs6jc07tbj" path="res://world/interactable/activators/switch/switch.tscn" id="1_7e3s6"]
+[ext_resource type="Script" path="res://world/interactable/activators/multi_activator/multi_activator.gd" id="2_6thiq"]
+[ext_resource type="PackedScene" uid="uid://blh1fs712dql8" path="res://world/interactable/activatable/locked_door/locked_door.tscn" id="3_ohm3n"]
+[ext_resource type="PackedScene" uid="uid://c7ck7ril2jix2" path="res://player/player.tscn" id="4_ndtqs"]
+[ext_resource type="PackedScene" uid="uid://b5bscusffqp5h" path="res://world/interactable/activators/pressure_plate/pressure_plate.tscn" id="5_jkywq"]
+
+[node name="MultiSwitchTest" type="Node2D"]
+
+[node name="Switch" parent="." instance=ExtResource("1_7e3s6")]
+position = Vector2(555, 92)
+type = 1
+metadata/Activatables = [NodePath("../MultiActivator")]
+
+[node name="Switch2" parent="." instance=ExtResource("1_7e3s6")]
+position = Vector2(242, 267)
+type = 1
+metadata/Activatables = [NodePath("../MultiActivator")]
+
+[node name="PressurePlate" parent="." instance=ExtResource("5_jkywq")]
+position = Vector2(841, 481)
+scale = Vector2(1.6456, 1.6456)
+metadata/Activatables = [NodePath("../MultiActivator")]
+
+[node name="MultiActivator" type="Node2D" parent="." groups=["Activatable", "Activator"]]
+position = Vector2(564, 342)
+script = ExtResource("2_6thiq")
+required_activation_count = 3
+metadata/Activatables = [NodePath("../LockedDoor")]
+
+[node name="LockedDoor" parent="." instance=ExtResource("3_ohm3n")]
+position = Vector2(905, 199)
+key_usable = false
+
+[node name="Player" parent="." instance=ExtResource("4_ndtqs")]
+position = Vector2(507, 528)

--- a/test_scenes/multi_switch_test.tscn
+++ b/test_scenes/multi_switch_test.tscn
@@ -1,33 +1,31 @@
 [gd_scene load_steps=6 format=3 uid="uid://d3gw8agbyr31b"]
 
 [ext_resource type="PackedScene" uid="uid://b60qs6jc07tbj" path="res://world/interactable/activators/switch/switch.tscn" id="1_7e3s6"]
-[ext_resource type="Script" path="res://world/interactable/activators/multi_activator/multi_activator.gd" id="2_6thiq"]
+[ext_resource type="PackedScene" uid="uid://dkpkuoehax8dx" path="res://world/interactable/activators/multi_activator/multi_activator.tscn" id="3_jhayb"]
 [ext_resource type="PackedScene" uid="uid://blh1fs712dql8" path="res://world/interactable/activatable/locked_door/locked_door.tscn" id="3_ohm3n"]
 [ext_resource type="PackedScene" uid="uid://c7ck7ril2jix2" path="res://player/player.tscn" id="4_ndtqs"]
 [ext_resource type="PackedScene" uid="uid://b5bscusffqp5h" path="res://world/interactable/activators/pressure_plate/pressure_plate.tscn" id="5_jkywq"]
 
 [node name="MultiSwitchTest" type="Node2D"]
 
-[node name="Switch" parent="." instance=ExtResource("1_7e3s6")]
-position = Vector2(555, 92)
-type = 1
-metadata/Activatables = [NodePath("../MultiActivator")]
-
-[node name="Switch2" parent="." instance=ExtResource("1_7e3s6")]
-position = Vector2(242, 267)
-type = 1
-metadata/Activatables = [NodePath("../MultiActivator")]
-
-[node name="PressurePlate" parent="." instance=ExtResource("5_jkywq")]
-position = Vector2(841, 481)
-scale = Vector2(1.6456, 1.6456)
-metadata/Activatables = [NodePath("../MultiActivator")]
-
-[node name="MultiActivator" type="Node2D" parent="." groups=["Activatable", "Activator"]]
-position = Vector2(564, 342)
-script = ExtResource("2_6thiq")
+[node name="MultiActivator" parent="." instance=ExtResource("3_jhayb")]
 required_activation_count = 3
 metadata/Activatables = [NodePath("../LockedDoor")]
+
+[node name="Switch" parent="MultiActivator" instance=ExtResource("1_7e3s6")]
+position = Vector2(555, 92)
+type = 1
+metadata/Activatables = [NodePath("..")]
+
+[node name="Switch2" parent="MultiActivator" instance=ExtResource("1_7e3s6")]
+position = Vector2(242, 267)
+type = 1
+metadata/Activatables = [NodePath("..")]
+
+[node name="PressurePlate" parent="MultiActivator" instance=ExtResource("5_jkywq")]
+position = Vector2(841, 481)
+scale = Vector2(1.6456, 1.6456)
+metadata/Activatables = [NodePath("..")]
 
 [node name="LockedDoor" parent="." instance=ExtResource("3_ohm3n")]
 position = Vector2(905, 199)

--- a/world/interactable/activators/multi_activator/multi_activator.gd
+++ b/world/interactable/activators/multi_activator/multi_activator.gd
@@ -1,0 +1,20 @@
+extends Node2D
+
+@export var required_activation_count := 2
+
+signal switch_activated
+signal switch_deactivated
+
+var current_count := 0
+
+func activate() -> void:
+	current_count += 1
+	if current_count == required_activation_count:
+		switch_activated.emit()
+		print("Multi-activator activated")
+
+func deactivate() -> void:
+	if current_count == required_activation_count:
+		switch_deactivated.emit()
+		print("Multi-activator deactivated")
+	current_count -= 1

--- a/world/interactable/activators/multi_activator/multi_activator.tscn
+++ b/world/interactable/activators/multi_activator/multi_activator.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://dkpkuoehax8dx"]
+
+[ext_resource type="Script" path="res://world/interactable/activators/multi_activator/multi_activator.gd" id="1_wxiaw"]
+
+[node name="MultiActivator" type="Node2D" groups=["Activatable", "Activator"]]
+script = ExtResource("1_wxiaw")

--- a/world/interactable/activators/pressure_plate/pressure_plate.gd
+++ b/world/interactable/activators/pressure_plate/pressure_plate.gd
@@ -14,7 +14,7 @@ func _process(_delta: float) -> void:
 	if pressed != pressed_this_frame:
 		if pressed_this_frame:
 			switch_activated.emit()
-		if pressed_this_frame:
+		else:
 			switch_deactivated.emit()
 
 	pressed = pressed_this_frame


### PR DESCRIPTION
fixes #207 
Created a "multi_activator" scene, which allows an event to be triggered only when several activators are triggered.
For example, you can connect 3 switches to the multi-activator, and then connect the multi-activator to a locked door. This means the door will open only if all 3 switches are triggered.