### PR TITLE
Red coin Momentum & Red Coin Text Movement

### DIFF
--- a/world/interactable/activators/red_coin/red_coin.gd
+++ b/world/interactable/activators/red_coin/red_coin.gd
@@ -23,8 +23,7 @@ func consume(_consumer: Node2D) -> void:
 		$Sprite2D.queue_free()
 		
 		print(velocity)
-		physics_state = ItemPhysicsState.IDLE
-		velocity = Vector2.ZERO
+		physics_state = ItemPhysicsState.INTANGIBLE
 		
 		# waits a time then deletes entire object
 		await get_tree().create_timer(label_visible_time).timeout

--- a/world/interactable/activators/red_coin/red_coin.gd
+++ b/world/interactable/activators/red_coin/red_coin.gd
@@ -22,6 +22,10 @@ func consume(_consumer: Node2D) -> void:
 		$CollisionShape2D.queue_free()
 		$Sprite2D.queue_free()
 		
+		print(velocity)
+		physics_state = ItemPhysicsState.IDLE
+		velocity = Vector2.ZERO
+		
 		# waits a time then deletes entire object
 		await get_tree().create_timer(label_visible_time).timeout
 		queue_free()

--- a/world/interactable/activators/red_coin/red_coin.gd
+++ b/world/interactable/activators/red_coin/red_coin.gd
@@ -4,13 +4,17 @@ extends Item
 @onready var my_label := $Label
 @export var label_visible_time: float = 1.0
 
+var collected := false
+
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	assert(red_coin_manager != null, "Red coin at %s was not a child of a RedCoinManager!" % get_path())
 	red_coin_manager.increment_coin_count() #tells Manager it exist
 
 func consume(_consumer: Node2D) -> void:
+	if collected: return
 	if(_consumer.is_in_group("Player")):
+
 		# sound plays update UI?
 		print("RedCoin: picked up")
 		var coin_num: int = red_coin_manager.red_coin_collected() 
@@ -22,8 +26,8 @@ func consume(_consumer: Node2D) -> void:
 		$CollisionShape2D.queue_free()
 		$Sprite2D.queue_free()
 		
-		print(velocity)
 		physics_state = ItemPhysicsState.INTANGIBLE
+		collected = true
 		
 		# waits a time then deletes entire object
 		await get_tree().create_timer(label_visible_time).timeout

--- a/world/interactable/activators/red_coin/red_coin.tscn
+++ b/world/interactable/activators/red_coin/red_coin.tscn
@@ -24,6 +24,9 @@ offset_left = -19.0
 offset_top = -59.0
 offset_right = 21.0
 offset_bottom = -36.0
+theme_override_font_sizes/font_size = 60
+text = "
+"
 horizontal_alignment = 1
 
 [node name="PickUpArea" type="Area2D" parent="."]

--- a/world/interactable/pickups/item.gd
+++ b/world/interactable/pickups/item.gd
@@ -3,7 +3,8 @@ class_name Item
 
 enum ItemPhysicsState {
 	FOLLOWING,
-	IDLE
+	IDLE,
+	INTANGIBLE
 }
 
 var physics_state: ItemPhysicsState = ItemPhysicsState.IDLE;
@@ -18,6 +19,11 @@ func _on_pickup_area_body_entered(other: Node2D) -> void:
 		other.pickup_item(self)
 		
 func follow(other: Node2D, follow_speed: float) -> void:
+	
+	#When an item is something that should not be movable by the sword.
+	if physics_state == ItemPhysicsState.INTANGIBLE:
+		return
+		
 	target = other
 	speed = follow_speed
 	physics_state = ItemPhysicsState.FOLLOWING
@@ -35,6 +41,8 @@ func _process(_delta: float) -> void:
 			var cur_speed: float = velocity.length()
 			cur_speed = max(cur_speed - acceleration, 0)
 			velocity = velocity.normalized() * cur_speed
+		ItemPhysicsState.INTANGIBLE:
+			velocity = Vector2.ZERO
 	move_and_slide()
 			
 func consume(_consumer: Node2D) -> void:


### PR DESCRIPTION
Patches two bugs:
- Red coin text no longer has momentum when being collected via sword
- Red coin text can no longer be launched using the sword.


Resolves #228 