### PR TITLE
Avoidance Issues Fix

### DIFF
--- a/enemy/enemy.gd
+++ b/enemy/enemy.gd
@@ -170,8 +170,10 @@ func _process_agressive(delta: float) -> void:
 	#When the enemy is inside of the valid target region
 	
 	if (enemy_distance < agressive_target_distance_min) || (enemy_distance > agressive_target_distance_max):
+		
 		target_direction = player_location.direction_to(self.global_position)
 		target = player_location+target_direction*target_distance
+		approach(target)
 	#else:
 		##print(self.global_position.distance_squared_to(navigation_target))
 		#if(self.global_position.distance_squared_to(navigation_target)>100):
@@ -180,7 +182,7 @@ func _process_agressive(delta: float) -> void:
 		#target_direction = player_location.direction_to(self.global_position).rotated(randf_range(-1, 1) * angle_variance)
 		#target = player_location+target_direction*target_distance
 		
-	approach(target)
+	
 		
 func _process_stunned(_delta: float) -> void:
 	pass

--- a/enemy/enemy.gd
+++ b/enemy/enemy.gd
@@ -162,7 +162,7 @@ func _process_agressive(delta: float) -> void:
 	#Note that these variables are the square distance
 	var enemy_distance: float = self.position.distance_to(Player.instance.position)
 	var navigation_target_distance: float = navigation_target.distance_to(Player.instance.position)
-	var player_location: Vector2 = Player.instance.position
+	var player_location: Vector2 = Player.instance.global_position
 	var target_distance: float = agressive_target_distance_min+(agressive_target_distance_max-agressive_target_distance_min)/2
 	var target_direction: Vector2
 	

--- a/enemy/enemy.gd
+++ b/enemy/enemy.gd
@@ -51,7 +51,7 @@ var time_since_last_seen_player : float = 0.0
 @export var agressive_target_distance_max: int = 300
 
 @export var enemy_state : EnemyState = EnemyState.ROAMING
-var navigation_target: Vector2 = self.position
+var navigation_target: Vector2 = self.global_position
 
 @onready var original_position : Vector2 = position
 @onready var target_position: Vector2 = _get_roaming_target()
@@ -127,7 +127,7 @@ func on_death() -> void:
 	# pick an eligible item and get the scene path
 	var chosen: String = eligible_pickup_paths.pick_random()
 	var dropped_item: Node2D = load(chosen).instantiate()
-	dropped_item.position = position
+	dropped_item.global_position = global_position
 	add_sibling.call_deferred(dropped_item)
 	print("Item '", dropped_item.name, "' was dropped by ", get_path())
 
@@ -160,24 +160,26 @@ func _get_roaming_target() -> Vector2:
 	
 func _process_agressive(delta: float) -> void:
 	#Note that these variables are the square distance
-	var enemy_distance: float = self.position.distance_to(Player.instance.position)
-	var navigation_target_distance: float = navigation_target.distance_to(Player.instance.position)
+	var enemy_distance: float = self.global_position.distance_to(Player.instance.global_position)
 	var player_location: Vector2 = Player.instance.global_position
+	var navigation_target_distance: float = navigation_target.distance_to(player_location)
 	var target_distance: float = agressive_target_distance_min+(agressive_target_distance_max-agressive_target_distance_min)/2
 	var target_direction: Vector2
 	
 	var target : Vector2
 	#When the enemy is inside of the valid target region
 	
-	if (enemy_distance > agressive_target_distance_min) && (enemy_distance < agressive_target_distance_max):
-		if(self.position.distance_squared_to(navigation_target)>10):
-			pass
-		const angle_variance := deg_to_rad(10)
-		target_direction = player_location.direction_to(self.position).rotated(randf_range(-1, 1) * angle_variance)
-		target = player_location+target_direction*target_distance;
-	else:
-		target_direction = player_location.direction_to(self.position)
-		target = player_location+target_direction*target_distance;
+	if (enemy_distance < agressive_target_distance_min) || (enemy_distance > agressive_target_distance_max):
+		target_direction = player_location.direction_to(self.global_position)
+		target = player_location+target_direction*target_distance
+	#else:
+		##print(self.global_position.distance_squared_to(navigation_target))
+		#if(self.global_position.distance_squared_to(navigation_target)>100):
+			#return
+		#const angle_variance := deg_to_rad(90)
+		#target_direction = player_location.direction_to(self.global_position).rotated(randf_range(-1, 1) * angle_variance)
+		#target = player_location+target_direction*target_distance
+		
 	approach(target)
 		
 func _process_stunned(_delta: float) -> void:
@@ -189,6 +191,7 @@ func barked() -> void:
 
 func approach(target: Vector2) -> void:
 	if navigation_agent:
+		navigation_target = target
 		navigation_agent.set_target_position(target)
 
 ## Helper function for derived Enemy types to check whether or not they have

--- a/ui/pause_menu/pause_menu.tscn
+++ b/ui/pause_menu/pause_menu.tscn
@@ -334,8 +334,8 @@ vertical_alignment = 2
 [node name="OptionsMenu" parent="." instance=ExtResource("32_pok70")]
 visible = false
 
-[connection signal="pressed" from="Panel/Resume" to="." method="_on_menu_major_button_pressed"]
 [connection signal="pressed" from="Panel/Resume" to="." method="_on_resume_pressed"]
+[connection signal="pressed" from="Panel/Resume" to="." method="_on_menu_major_button_pressed"]
 [connection signal="pressed" from="Panel/Quit" to="." method="_on_menu_major_button_pressed"]
 [connection signal="pressed" from="Panel/Quit" to="." method="_on_quit_pressed"]
 [connection signal="pressed" from="Panel/OptionsMenuButton" to="." method="_on_menu_major_button_pressed"]

--- a/ui/title/title_screen.tscn
+++ b/ui/title/title_screen.tscn
@@ -238,10 +238,10 @@ visible = false
 
 [node name="MusicPlayer" parent="." instance=ExtResource("8_dxujq")]
 
-[connection signal="pressed" from="ContinueGame" to="." method="_on_continue_game_pressed"]
 [connection signal="pressed" from="ContinueGame" to="." method="_on_menu_major_button_pressed"]
-[connection signal="pressed" from="Quit" to="." method="_on_quit_pressed"]
+[connection signal="pressed" from="ContinueGame" to="." method="_on_continue_game_pressed"]
 [connection signal="pressed" from="Quit" to="." method="_on_menu_major_button_pressed"]
+[connection signal="pressed" from="Quit" to="." method="_on_quit_pressed"]
 [connection signal="pressed" from="NewGame" to="." method="_on_menu_major_button_pressed"]
 [connection signal="pressed" from="NewGame" to="." method="_on_new_game_pressed"]
 [connection signal="pressed" from="Options" to="." method="_on_menu_major_button_pressed"]

--- a/world/levels/test_levels/demo_dungeon.tscn
+++ b/world/levels/test_levels/demo_dungeon.tscn
@@ -13,7 +13,6 @@
 size = Vector2(158, 146)
 
 [node name="DemoDungeon" instance=ExtResource("1_i4l68")]
-position = Vector2(-699, -173)
 
 [node name="ColorRect" type="ColorRect" parent="." index="0"]
 z_index = -10

--- a/world/levels/test_levels/latest_demo_2.tscn
+++ b/world/levels/test_levels/latest_demo_2.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=39 format=4 uid="uid://c0b860627rcs5"]
+[gd_scene load_steps=38 format=4 uid="uid://c0b860627rcs5"]
 
 [ext_resource type="PackedScene" uid="uid://cnd06dpkgufe4" path="res://world/levels/level_base.tscn" id="1_2iy6g"]
 [ext_resource type="Script" path="res://world/decoration/trees/tree_gen.gd" id="2_n44bl"]
@@ -30,7 +30,6 @@
 [ext_resource type="PackedScene" uid="uid://yllbcpq24cl0" path="res://enemy/creep_enemy/creep_enemy.tscn" id="26_hg8qn"]
 [ext_resource type="PackedScene" uid="uid://dovs54pxe1oba" path="res://generic/particle_fixer/particle_fixer.tscn" id="27_h03p2"]
 [ext_resource type="PackedScene" uid="uid://bimerg4hcbya2" path="res://enemy/charging_enemy/charging_enemy.tscn" id="27_kqj6m"]
-[ext_resource type="PackedScene" uid="uid://c4q0hmrfl5yh2" path="res://enemy/frog_boss/frog_boss.tscn" id="31_1tm5l"]
 [ext_resource type="PackedScene" uid="uid://rap0uso4fckx" path="res://dj_music_man/music_players/instant_music_player.tscn" id="32_tlxi0"]
 
 [sub_resource type="Curve2D" id="Curve2D_j10fm"]
@@ -595,10 +594,10 @@ knockback_friction = 3.0
 [node name="TileMapLayer" parent="." index="18" instance=ExtResource("15_nkduh")]
 position = Vector2(783, 1805)
 
-[node name="Frog Boss" parent="." index="20" instance=ExtResource("31_1tm5l")]
-position = Vector2(868, 1867)
+[node name="MusicPlayer" parent="." index="20" instance=ExtResource("32_tlxi0")]
 
-[node name="MusicPlayer" parent="." index="21" instance=ExtResource("32_tlxi0")]
+[node name="ProjectileEnemy" parent="." index="21" instance=ExtResource("12_t5ow0")]
+position = Vector2(625, 2115)
 
 [connection signal="body_entered" from="PuzzleArea/DungeonEntrance/TransitionScene" to="PuzzleArea/DungeonEntrance/TransitionScene" method="_on_body_entered"]
 [connection signal="body_entered" from="BossArea/DungeonEntrance/TransitionScene" to="BossArea/DungeonEntrance/TransitionScene" method="_on_body_entered"]


### PR DESCRIPTION
The position of the root node in demo_dungeon.tscn was set to a non-zero value, causing the test enemy to think the player was farther to the right than it actually was. 

Aggressive enemy targeting now uses player.global_position, and to be safe the location of the demo_dungeon.tscn has been moved back to (0,0)

Fixes #168 